### PR TITLE
fix missing import for exceptions example

### DIFF
--- a/src/getting_started/exceptions/index.rst
+++ b/src/getting_started/exceptions/index.rst
@@ -312,7 +312,8 @@ whether the code succeeded or failed.  For example:
 
 .. python-run::
    :formatting: separate
-
+   import sys
+   
    def divide(a,b):
        ''' Divide a by b and catch exceptions'''
 


### PR DESCRIPTION
There's an example involving exceptions that is broken in the textbook - see attached screenshot:

<img width="718" alt="image" src="https://github.com/computer-science-with-applications/book/assets/7931270/3eda769b-744f-48f5-8ead-8e2659c7d03b">

It looks like the `finally` block did not execute correctly for the final example.

I've put in a fix but have not built the textbook to test if the fix works (I'm not well-versed with Sphinx). 